### PR TITLE
Install and test for bdist_conda

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,5 @@
+python setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1
+
+copy bdist_conda.py "%PREFIX%\Lib\distutils\command\"
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python setup.py install --single-version-externally-managed --record=record.txt
+
+cp bdist_conda.py "${PREFIX}/lib/python${PY_VER}/distutils/command/"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,10 +51,15 @@ test:
   #   - pytest
   #   - pytest-timeout
   #   - pytest-catchlog
+
+  files:
+    - test_bdist_conda_setup.py
+
   imports:
     - conda_build
 
   commands:
+    # Check for all subcommands
     - which conda-build  # [unix]
     - where conda-build  # [win]
     - conda-build -h
@@ -84,6 +89,9 @@ test:
     - which conda-skeleton  # [unix]
     - where conda-skeleton  # [win]
     - conda-skeleton -h
+
+    # Check for bdist_conda
+    - python test_bdist_conda_setup.py bdist_conda --help
 
 about:
   home: https://github.com/conda/conda-build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: conda-build-{{ version }}.tar.gz
   url: https://github.com/conda/conda-build/archive/{{ version }}.tar.gz
-  sha256: 716e44d9be0a63a3fdbf19a9aa595d6219649282bd2e8f480aed132e26b06ef8
+  sha256: e4ef0b56cab8aee03d1fdd87e5d63afa628b2c455abb33716596825fd1338909
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,8 @@ source:
   sha256: e4ef0b56cab8aee03d1fdd87e5d63afa628b2c455abb33716596825fd1338909
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py==36]
-  script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main

--- a/recipe/test_bdist_conda_setup.py
+++ b/recipe/test_bdist_conda_setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup, Extension
+import distutils.command.bdist_conda
+
+setup(
+    name="package",
+    version="1.0.0",
+    distclass=distutils.command.bdist_conda.CondaDistribution
+)


### PR DESCRIPTION
We were not installing or testing for `bdist_conda` previously. This adds an explicit installation step for `bdist_conda` on Unix and Windows. Also adds a simple test to verify that `bdist_conda` works ok.

Note: Based off of PR ( https://github.com/conda-forge/conda-build-feedstock/pull/9 ) to handle the checksum change.