### PR TITLE
Add core as maintainers [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,4 +100,10 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus
     - msarahan
+    - mwcraig
+    - ocefpaf
+    - patricksnape
+    - pelson
+    - scopatz


### PR DESCRIPTION
This explicitly adds all of @conda-forge/core as maintainers of `conda-build`. As this is our `conda-build` package and determines, which version we are using as latest. It is paramount that all of core explicitly has access should they need it. This provides that access.