### PR TITLE
Update to 2.1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
-{% set version = "2.1.4" %}
+{% set name = "conda-build" %}
+{% set version = "2.1.6" %}
+{% set sha256 = "8f13b7a596a813427f505b79ea75bb099deefb725cf49f3949bfffadf990b3da" %}
 
 package:
-  name: conda-build
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: conda-build-{{ version }}.tar.gz
-  url: https://github.com/conda/conda-build/archive/{{ version }}.tar.gz
-  sha256: 864ce9d28331e61050c226b0c9e586e930bcd2b925ab0525ed3d2d8accd56069
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/conda/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 1
@@ -42,6 +44,7 @@ requirements:
     - pycrypto
     - python
     - pyyaml
+    - six
 
 test:
   # If you run the test suite (~10 min), these are required
@@ -95,6 +98,8 @@ about:
   home: https://github.com/conda/conda-build
   summary: tools for building conda packages
   license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:
@@ -106,3 +111,4 @@ extra:
     - patricksnape
     - pelson
     - scopatz
+    - stuertz


### PR DESCRIPTION
Need the update to 2.1.6 to build pyslet (https://github.com/conda-forge/staged-recipes/pull/2534) on windows/py27. Otherwise the build fails with unicode issues due to non ascii filenames in the. tar.gz

Also made use of variables as in example and added licence infos