### PR TITLE
Release 2.1.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -67,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -75,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,3 +3,6 @@ if errorlevel 1 exit 1
 
 copy bdist_conda.py "%PREFIX%\Lib\distutils\command\"
 if errorlevel 1 exit 1
+
+del /f /q "%PREFIX%\Scripts\conda"
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,3 +3,5 @@
 python setup.py install --single-version-externally-managed --record=record.txt
 
 cp bdist_conda.py "${PREFIX}/lib/python${PY_VER}/distutils/command/"
+
+rm -f "${PREFIX}/bin/conda"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
 {% set version = "2.1.10" %}
-{% set sha256 = "5fde00022efb55a89297816296b3eb419cdaa3d265e7b2ce9c5885e2222e4754" %}
+{% set sha256 = "5135bab697f79a66470aa139bde4fdbe79e4b7136561966d844c15b4959ca5c9" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "2.1.9" %}
-{% set sha256 = "a45463d2e20a73c2dd6794e25dc72935da8711fea4507a680ac2d05db9ce6330" %}
+{% set version = "2.1.10" %}
+{% set sha256 = "5fde00022efb55a89297816296b3eb419cdaa3d265e7b2ce9c5885e2222e4754" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
```
2016-08-02 1.21.10:
-------------------

Bug fixes:
----------

* Compile files ending with .py, not py.  #1163
* Move root logger to entry points, to not interfere with conda #1164 #1166
* Use setuptools entry points, rather than pre-defined scripts #1165
* Always use the long build prefix to avoid confusion #1168

Contributors:
-------------

* @mingwandroid
* @msarahan
```