### PR TITLE
Release 2.1.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "2.1.10" %}
-{% set sha256 = "5135bab697f79a66470aa139bde4fdbe79e4b7136561966d844c15b4959ca5c9" %}
+{% set version = "2.1.12" %}
+{% set sha256 = "8d4ca4f56e75a28d69d9205c6fd2d4721d815e9dabab82db8f834a4c6ec64254" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
```
2017-05-09 2.1.12:

Bug fixes:
----------

* Clean up lock files for temporary directories also

Contributors:
-------------

* @msarahan

2017-05-09 2.1.11:

Enhancements:
-------------

* add libgcc to build dependencies for R skeleton recipes that require compilation  $1969

Bug fixes:
----------

* fix entry points, test commands, test imports from top-level recipe from applying to subpackages  #1933
* fix preferred_env in index.json  #1941
* do not add python.app to run_reqs multiple times  #1981
* Fix $ORIGIN replacement from extra trailing slash  #1981
* Remove error when _license package exists in folder where ``conda index`` is called  #2005
* fix STDLIB_DIR so that it is always defined (based on python version in configuration)  #2006
* Clean up lock files after builds complete or fail to avoid permission errors  #2007

Contributors:
-------------

* @johanneskoester
* @kalefranz
* @mingwandroid
* @msarahan
```