### PR TITLE
Release 2.1.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "2.1.10" %}
-{% set sha256 = "5135bab697f79a66470aa139bde4fdbe79e4b7136561966d844c15b4959ca5c9" %}
+{% set version = "2.1.15" %}
+{% set sha256 = "39c78ef006890f491bbe8a25b46e3288c3b6af66f2aa4e3e414a670f05773a05" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
```rst
2017-05-18 2.1.15:

Bug fixes:
----------

* Fix windows entry point exe's for spaces in the final exe path  #2039

Contributors:
-------------

* @mingwandroid


2017-05-17 2.1.14:

Enhancements:
-------------

* Add new entry point EXE's for windows that support unicode  #2031, #2033

Contributors:
-------------

* @mingwandroid


2017-05-10 2.1.13:

Bug fixes:
----------

* fix missing argument to get_site_packages function; add test coverage  #2009
* pin codecov on appveyor to 2.0.5 for now  #2009
* fix lock removal (just don't create locks for temporary directories)  #2009

Contributors:
-------------

* @msarahan


2017-05-09 2.1.12:

Bug fixes:
----------

* Clean up lock files for temporary directories also

Contributors:
-------------

* @msarahan

2017-05-09 2.1.11:

Enhancements:
-------------

* add libgcc to build dependencies for R skeleton recipes that require compilation  $1969

Bug fixes:
----------

* fix entry points, test commands, test imports from top-level recipe from applying to subpackages  #1933
* fix preferred_env in index.json  #1941
* do not add python.app to run_reqs multiple times  #1981
* Fix $ORIGIN replacement from extra trailing slash  #1981
* Remove error when _license package exists in folder where ``conda index`` is called  #2005
* fix STDLIB_DIR so that it is always defined (based on python version in configuration)  #2006
* Clean up lock files after builds complete or fail to avoid permission errors  #2007

Contributors:
-------------

* @johanneskoester
* @kalefranz
* @mingwandroid
* @msarahan
```