### PR TITLE
Rebuild in presence of the new `conda` package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main


### PR DESCRIPTION
Have noticed some logging messages coming through during various build operations with `conda-build`. Suspect this was a consequence of the old `conda` 4.3.21 build, which hadn't updated the build scripts. Now that `conda` has been rebuilt correctly, it seems worthwhile to try just rebuilding `conda-build` to see if this issue goes away.