### PR TITLE
Release 2.1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "2.1.17" %}
-{% set sha256 = "41638eb655810bfc141d36a745c8e936bb75387c8cb56947f2937892a6435b19" %}
+{% set version = "2.1.18" %}
+{% set sha256 = "d08924539c95a1343a72f114d61e25685072ae5f704710a9fbe5dfda404b5564" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
```
2017-09-12 2.1.18:
------------------

Bug fixes:
----------

* add SSL_CERT_FILE and REQUESTS_CA_BUNDLE to build env pass-through variables
* allow blank values for certain keys in cran-skeleton  #2153
* Ignore feature records in index for ``conda inspect``  #2253
* backport relax entry_points syntax from #1894  #2348
* delete "cc" (conda config instance) only after all usage  #2365
* backport "only set env vars in build scripts that actually have values" from #2259; #2528

Contributors:
-------------

* @aburgm
* @jakirkham
* @jjhelmus
* @kalefranz
* @nehaljwani
```