### PR TITLE
3.12.0; sync with defaults

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python setup.py install --single-version-externally-managed --record=record.txt
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt
 
 cp bdist_conda.py "${PREFIX}/lib/python${PY_VER}/distutils/command/"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.2.2" %}
-{% set sha1 = "73a27db4aff1cba9c8213d73f67b28c7e187319a" %}
+{% set version = "3.3.0" %}
+{% set sha1 = "fe308a2527528bb3645b6595fa41e846badbb8b7" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.11.0" %}
-{% set sha256 = "4712330ffc3e28e21f72bd05d3fac3c00e8db417efe1996f1a896c17c1152513" %}
+{% set version = "3.0.10" %}
+{% set sha256 = "c71b727d311eda720f54a7c13609c0a9a2c61fc36c7281f4cc0f50b47a773c57" %}
 
 package:
   name: {{ name }}
@@ -31,14 +31,14 @@ requirements:
     - chardet
     - conda  >=4.3
     - conda-verify
-    - contextlib2   # [py<34]
-    - enum34        # [py<34]
+    - contextlib2        # [py27]
+    - enum34             # [py27]
     - filelock
-    - futures       # [py<3]
+    - futures            # [py27]
+    - glob2
     - jinja2
     - patchelf      # [linux]
     - pkginfo
-    - psutil
     - python
     - pyyaml
     - scandir       # [py<34]
@@ -49,8 +49,10 @@ test:
   # If you run the test suite (~10 min), these are required
   # requires:
   #   - pytest
-  #   - pytest-timeout
+  #   - pytest-cov
   #   - pytest-catchlog
+  #   - pytest-xdist
+  #   - pytest-env
 
   files:
     - test_bdist_conda_setup.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.4" %}
-{% set sha1 = "ba62b3dde8dd62f41c2b6c53001e6de501cc58f5" %}
+{% set version = "3.10.6" %}
+{% set sha1 = "31136556f547b863d8da8d6ab12745b0f744de8a" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.9.1" %}
-{% set sha1 = "ddd0fca69f2d939faac22c191618fb646b52f2a3" %}
+{% set version = "3.9.2" %}
+{% set sha1 = "aa7cfc5540f7d8c88cfbb8dca0ec4569732514a1" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,11 @@ about:
   license: BSD 3-Clause
   license_family: BSD
   license_file: LICENSE.txt
+  description: |
+    Conda-build contains commands and tools to allow you to build your own
+    packages for conda.
+  doc_url: http://conda.pydata.org/docs/
+  dev_url: https://github.com/conda/conda-build
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.30" %}
-{% set sha1 = "03d512483a188934390457de485b9df77182ea65" %}
+{% set version = "3.1.0" %}
+{% set sha1 = "537c64ff93b433a62605cd641bdfd991bb5e1bc0" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
     - conda-skeleton = conda_build.cli.main_skeleton:main
 
 requirements:
-  build:
+  host:
     - python
     - pip
   run:
@@ -101,6 +101,7 @@ extra:
   recipe-maintainers:
     - jakirkham
     - jjhelmus
+    - mingwandroid
     - msarahan
     - mwcraig
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.20" %}
-{% set sha1 = "fee8c5360048ae4363107959eb69ded0d6eac4d5" %}
+{% set version = "3.0.21" %}
+{% set sha1 = "81ff217c4420ddb914c38e34ad06d5f658b8988c" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.16" %}
-{% set sha256 = "7a5ce20786dd1a86a31feefdb41c85e9fb28d92df4ef05134555ddc9d675dda2" %}
+{% set version = "3.0.17" %}
+{% set sha256 = "f46105c5ff78bb8852538617915cdabed68dc2a07e5797d4657addd199bd96e9" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.6" %}
-{% set sha1 = "31136556f547b863d8da8d6ab12745b0f744de8a" %}
+{% set version = "3.10.7" %}
+{% set sha1 = "a0ba09c418e1301399c391d12f7e94ac6611119b" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.5.1" %}
-{% set sha1 = "40d8c2d64ca945393956c2f177c0bb56e6a34f25" %}
+{% set version = "3.7.1" %}
+{% set sha1 = "6b8f4b57f559b18d0b671257f7d58b571f90b45e" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.7.1" %}
-{% set sha1 = "6b8f4b57f559b18d0b671257f7d58b571f90b45e" %}
+{% set version = "3.7.2" %}
+{% set sha1 = "eb0924338656820f743f1ef08cbde05f55d83688" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.9.0" %}
-{% set sha1 = "d8727a6a11d953431cf5132a105f630f3b630b71" %}
+{% set version = "3.9.1" %}
+{% set sha1 = "ddd0fca69f2d939faac22c191618fb646b52f2a3" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.8" %}
-{% set sha1 = "a0ba09c418e1301399c391d12f7e94ac6611119b" %}
+{% set version = "3.10.9" %}
+{% set sha1 = "16ace37dec26f91f42d9e8429589336b6552f711" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.22" %}
-{% set sha1 = "eaf21bcb8df2ccd06c6ee8977819fe963fd0218a" %}
+{% set version = "3.0.23" %}
+{% set sha1 = "74fb8ea7cd127e4c413d4b07060cb54bd0402ece" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.12" %}
-{% set sha256 = "27719278dc4f4f717116375dbad1bb04040b284874e881dd751a8a1433476e4a" %}
+{% set version = "3.0.13" %}
+{% set sha256 = "70dbcb9af950d2702c3eb9895d39996e0b58588644741e9f5dd23147e8911ccd" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   git_tag: {{ sha1 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
@@ -35,7 +35,7 @@ requirements:
     - enum34             # [py27]
     - filelock
     - futures            # [py27]
-    - glob2
+    - glob2 >=0.6
     - jinja2
     - patchelf      # [linux]
     - pkginfo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.2.0" %}
-{% set sha1 = "8f5d297204666b4096ccfbe55552c03c4d06bf95" %}
+{% set version = "3.2.1" %}
+{% set sha1 = "40f78f8c99424dd11051870fd3f516d3f8c980ff" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
 {% set version = "3.0.11" %}
-{% set sha256 = "960bc0f3818b040c7694b9b09dce6d177c13f6436cb37a345a5b5958d950c311" %}
+{% set sha256 = "3dd4b11c9c3ba00a1422a2f85f79d33c5dcd74791020824e9bda618651ec8c49" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.23" %}
-{% set sha1 = "74fb8ea7cd127e4c413d4b07060cb54bd0402ece" %}
+{% set version = "3.0.24" %}
+{% set sha1 = "9021e40a0ba7bfaaa411c00dbfad3870904a52d2" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.11.0" %}
-{% set sha1 = "9e0e7f124fa5cfa2adc79bb254b80323fc34a35b" %}
+{% set version = "3.12.0" %}
+{% set sha1 = "60401f5cfef46c4341d52cd5d65ebf49384a69f6" %}
 
 package:
   name: {{ name }}
@@ -30,12 +30,11 @@ requirements:
     - beautifulsoup4
     - chardet
     - conda  >=4.3
-    - conda-verify
     - contextlib2        # [py27]
     - enum34             # [py27]
     - filelock
     - futures            # [py27]
-    - glob2 >=0.6
+    - glob2 >=0.6        # [py27]
     - jinja2
     - patchelf      # [linux]
     - pkginfo
@@ -45,6 +44,9 @@ requirements:
     - scandir            # [py27]
     - six
     - glob2 >=0.6
+
+  run_constrained:
+    - conda-verify  >=3.1.0
 
 test:
   # If you run the test suite (~10 min), these are required

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.4.1" %}
-{% set sha1 = "580e54b2f1346df0004808df064013c339c7a3a7" %}
+{% set version = "3.5.0" %}
+{% set sha1 = "48e1a270d715a9070775b62d7f82c291c37e154b" %}
 
 package:
   name: {{ name }}
@@ -39,9 +39,10 @@ requirements:
     - jinja2
     - patchelf      # [linux]
     - pkginfo
+    - psutil
     - python
     - pyyaml
-    - scandir       # [py<34]
+    - scandir            # [py27]
     - six
     - glob2 >=0.6
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.27" %}
-{% set sha1 = "62be04c1fcedde3745f4486019c2637c0ae3b7e0" %}
+{% set version = "3.0.28" %}
+{% set sha1 = "cfc93d292402e826e5e6f3da2278d0edde1fb3ec" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.5.0" %}
-{% set sha1 = "48e1a270d715a9070775b62d7f82c291c37e154b" %}
+{% set version = "3.5.1" %}
+{% set sha1 = "40d8c2d64ca945393956c2f177c0bb56e6a34f25" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.13" %}
-{% set sha256 = "70dbcb9af950d2702c3eb9895d39996e0b58588644741e9f5dd23147e8911ccd" %}
+{% set version = "3.0.14" %}
+{% set sha256 = "26a85b7ae7f2fc485ab5790baf9b154d91f731a9e5254ccf4d367852836fda6f" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.9" %}
-{% set sha1 = "16ace37dec26f91f42d9e8429589336b6552f711" %}
+{% set version = "3.11.0" %}
+{% set sha1 = "9e0e7f124fa5cfa2adc79bb254b80323fc34a35b" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.1" %}
-{% set sha1 = "edac5097ddb8a004e38cfe379af5da0f8f6756de" %}
+{% set version = "3.10.2" %}
+{% set sha1 = "70ddd6cfc3b96c25cda28eaf930043dd4311f948" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.2" %}
-{% set sha1 = "70ddd6cfc3b96c25cda28eaf930043dd4311f948" %}
+{% set version = "3.10.3" %}
+{% set sha1 = "a17242ddf305994cd01c22b949a9015b2d692b01" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.17" %}
-{% set sha256 = "f46105c5ff78bb8852538617915cdabed68dc2a07e5797d4657addd199bd96e9" %}
+{% set version = "3.0.18" %}
+{% set sha1 = "c8ddc5671d90f105ac6f08f6572c0f5211941521" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/conda/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  git_url: https://github.com/conda/conda-build
+  git_tag: {{ sha1 }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.2.1" %}
-{% set sha1 = "40f78f8c99424dd11051870fd3f516d3f8c980ff" %}
+{% set version = "3.2.2" %}
+{% set sha1 = "73a27db4aff1cba9c8213d73f67b28c7e187319a" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.1.6" %}
-{% set sha1 = "be209d77f3aa728ee9dea9c43a6cce78468e7f95" %}
+{% set version = "3.2.0" %}
+{% set sha1 = "8f5d297204666b4096ccfbe55552c03c4d06bf95" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.1.5" %}
-{% set sha1 = "9b62249a8a5ff2afb84f71a3c53531b4c2048bd0" %}
+{% set version = "3.1.6" %}
+{% set sha1 = "be209d77f3aa728ee9dea9c43a6cce78468e7f95" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.24" %}
-{% set sha1 = "9021e40a0ba7bfaaa411c00dbfad3870904a52d2" %}
+{% set version = "3.0.25" %}
+{% set sha1 = "a6c1815e074e29081da630eda54f94c09213cf50" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
 {% set version = "3.0.12" %}
-{% set sha256 = "b55b589e296c7aef943868b148a7051c4d8f2fd7eea1dbb97a14d1df6cd87de6" %}
+{% set sha256 = "27719278dc4f4f717116375dbad1bb04040b284874e881dd751a8a1433476e4a" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.3.0" %}
-{% set sha1 = "fe308a2527528bb3645b6595fa41e846badbb8b7" %}
+{% set version = "3.4.0" %}
+{% set sha1 = "aed0b809a940477690aec61aacbed17f2e46aafb" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.26" %}
-{% set sha1 = "431df81a8b1fa3f7033e0fa67c07e0a49acb5b80" %}
+{% set version = "3.0.27" %}
+{% set sha1 = "62be04c1fcedde3745f4486019c2637c0ae3b7e0" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.14" %}
-{% set sha256 = "26a85b7ae7f2fc485ab5790baf9b154d91f731a9e5254ccf4d367852836fda6f" %}
+{% set version = "3.0.15" %}
+{% set sha256 = "a515a839ef3c0b27ec47991d61b7eaa13413edf8f3964f24227838bad4964cfb" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.3" %}
-{% set sha1 = "a17242ddf305994cd01c22b949a9015b2d692b01" %}
+{% set version = "3.10.4" %}
+{% set sha1 = "ba62b3dde8dd62f41c2b6c53001e6de501cc58f5" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.19" %}
-{% set sha1 = "88da5edf0f4746ab11b7410844613c03e550d6bb" %}
+{% set version = "3.0.20" %}
+{% set sha1 = "fee8c5360048ae4363107959eb69ded0d6eac4d5" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.10" %}
-{% set sha256 = "c71b727d311eda720f54a7c13609c0a9a2c61fc36c7281f4cc0f50b47a773c57" %}
+{% set version = "3.0.11" %}
+{% set sha256 = "960bc0f3818b040c7694b9b09dce6d177c13f6436cb37a345a5b5958d950c311" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.21" %}
-{% set sha1 = "81ff217c4420ddb914c38e34ad06d5f658b8988c" %}
+{% set version = "3.0.22" %}
+{% set sha1 = "eaf21bcb8df2ccd06c6ee8977819fe963fd0218a" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.7.2" %}
-{% set sha1 = "eb0924338656820f743f1ef08cbde05f55d83688" %}
+{% set version = "3.8.0" %}
+{% set sha1 = "54f9b398c5f918d84a7a3488c2c43b52770ce0b1" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.25" %}
-{% set sha1 = "a6c1815e074e29081da630eda54f94c09213cf50" %}
+{% set version = "3.0.26" %}
+{% set sha1 = "431df81a8b1fa3f7033e0fa67c07e0a49acb5b80" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.29" %}
-{% set sha1 = "84e078226d19d0b00fecde5120cdb72924d1d5ab" %}
+{% set version = "3.0.30" %}
+{% set sha1 = "03d512483a188934390457de485b9df77182ea65" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.28" %}
-{% set sha1 = "cfc93d292402e826e5e6f3da2278d0edde1fb3ec" %}
+{% set version = "3.0.29" %}
+{% set sha1 = "84e078226d19d0b00fecde5120cdb72924d1d5ab" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-build" %}
-{% set version = "3.10.7" %}
+{% set version = "3.10.8" %}
 {% set sha1 = "a0ba09c418e1301399c391d12f7e94ac6611119b" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.15" %}
-{% set sha256 = "a515a839ef3c0b27ec47991d61b7eaa13413edf8f3964f24227838bad4964cfb" %}
+{% set version = "3.0.16" %}
+{% set sha256 = "7a5ce20786dd1a86a31feefdb41c85e9fb28d92df4ef05134555ddc9d675dda2" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.8.0" %}
-{% set sha1 = "54f9b398c5f918d84a7a3488c2c43b52770ce0b1" %}
+{% set version = "3.8.1" %}
+{% set sha1 = "ff48f4eb8ae808ba8d3f2090af809af68776008a" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.11" %}
-{% set sha256 = "3dd4b11c9c3ba00a1422a2f85f79d33c5dcd74791020824e9bda618651ec8c49" %}
+{% set version = "3.0.12" %}
+{% set sha256 = "b55b589e296c7aef943868b148a7051c4d8f2fd7eea1dbb97a14d1df6cd87de6" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.1.4" %}
-{% set sha1 = "a14d1c67b010e85b8943675ebefa811a4a41b777" %}
+{% set version = "3.1.5" %}
+{% set sha1 = "9b62249a8a5ff2afb84f71a3c53531b4c2048bd0" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.8.1" %}
-{% set sha1 = "ff48f4eb8ae808ba8d3f2090af809af68776008a" %}
+{% set version = "3.9.0" %}
+{% set sha1 = "d8727a6a11d953431cf5132a105f630f3b630b71" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.1.0" %}
-{% set sha1 = "537c64ff93b433a62605cd641bdfd991bb5e1bc0" %}
+{% set version = "3.1.3" %}
+{% set sha1 = "35e3076deb11bf86d7f408576f4de38bf1bd88c9" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.4.0" %}
-{% set sha1 = "aed0b809a940477690aec61aacbed17f2e46aafb" %}
+{% set version = "3.4.1" %}
+{% set sha1 = "580e54b2f1346df0004808df064013c339c7a3a7" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.9.2" %}
-{% set sha1 = "aa7cfc5540f7d8c88cfbb8dca0ec4569732514a1" %}
+{% set version = "3.10.1" %}
+{% set sha1 = "edac5097ddb8a004e38cfe379af5da0f8f6756de" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.1.3" %}
-{% set sha1 = "35e3076deb11bf86d7f408576f4de38bf1bd88c9" %}
+{% set version = "3.1.4" %}
+{% set sha1 = "a14d1c67b010e85b8943675ebefa811a4a41b777" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.0.18" %}
-{% set sha1 = "c8ddc5671d90f105ac6f08f6572c0f5211941521" %}
+{% set version = "3.0.19" %}
+{% set sha1 = "88da5edf0f4746ab11b7410844613c03e550d6bb" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,30 +62,30 @@ test:
 
   commands:
     # Check for all subcommands
-    - which conda-build  # [unix]
+    - type -P conda-build  # [unix]
     - where conda-build  # [win]
     - conda-build -h
-    - which conda-convert  # [unix]
+    - type -P conda-convert  # [unix]
     - where conda-convert  # [win]
     - conda-convert -h
-    - which conda-develop  # [unix]
+    - type -P conda-develop  # [unix]
     - where conda-develop  # [win]
     - conda-develop -h
-    - which conda-index  # [unix]
+    - type -P conda-index  # [unix]
     - where conda-index  # [win]
     - conda-index -h
-    - which conda-inspect  # [unix]
+    - type -P conda-inspect  # [unix]
     - where conda-inspect  # [win]
     - conda-inspect linkages -h \| grep "--name ENVIRONMENT"  # [unix]
     - conda-inspect objects -h \| grep "--name ENVIRONMENT"   # [osx]
     - conda-inspect -h
-    - which conda-metapackage  # [unix]
+    - type -P conda-metapackage  # [unix]
     - where conda-metapackage  # [win]
     - conda-metapackage -h
-    - which conda-render  # [unix]
+    - type -P conda-render  # [unix]
     - where conda-render  # [win]
     - conda-render -h
-    - which conda-skeleton  # [unix]
+    - type -P conda-skeleton  # [unix]
     - where conda-skeleton  # [win]
     - conda-skeleton -h
 


### PR DESCRIPTION
bump to 3.12.0.  The moves conda-verify to run_constrained instead of just run.

This should also make this repo mergeable with defaults in the future.