### PR TITLE
3.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - pkginfo
     - psutil
     - python
-    - py-lief
+    - py-lief  # [not (win and py2k)]
     - pyyaml
     - scandir            # [py27]
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-build" %}
-{% set version = "3.16.3" %}
-{% set sha256 = "fdf103132d8eedd4cf8b41a70377d72428dbf4527c735190fa939484eea82571" %}
+{% set version = "3.17.0" %}
+{% set sha256 = "6e1ed8f60baa295cd315373e3ea566b37deb21642ca5a0e63553f6011521fe2c" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
+    - conda-debug = conda_build.cli.main_debug:main
     - conda-develop = conda_build.cli.main_develop:main
     - conda-index = conda_build.cli.main_index:main
     - conda-inspect = conda_build.cli.main_inspect:main
@@ -42,6 +43,7 @@ requirements:
     - pkginfo
     - psutil
     - python
+    - py-lief
     - pyyaml
     - scandir            # [py27]
     - six
@@ -77,6 +79,8 @@ test:
     - conda-convert -h
     - type -P conda-develop  # [unix]
     - where conda-develop  # [win]
+    - type -P conda-debug  # [unix]
+    - where conda-debug  # [win]
     - conda-develop -h
     - type -P conda-index  # [unix]
     - where conda-index  # [win]


### PR DESCRIPTION
includes updated entrypoints and py-lief on #77

py-lief is not on conda-forge yet.