### PR TITLE
Add ripgrep to run requirements on x86_64 (linux64, osx, win64)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
@@ -43,6 +43,7 @@ requirements:
     - python
     - py-lief            # [not (win and py2k)]
     - pyyaml
+    - ripgrep            # [x86_64]
     - scandir            # [py27]
     - setuptools
     - six


### PR DESCRIPTION
Removes the warning during build:

"WARNING: Detecting which files contain PREFIX is slow, installing ripgrep makes it faster."
              " 'conda install ripgrep'"

closes https://github.com/conda-forge/conda-build-feedstock/issues/102

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
