### PR TITLE
Add `patch` and `cctools` dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - requests
     - patch    >=2.6     # [not win]
     - m2-patch >=2.6     # [win]
+    - cctools            # [osx]
 
   run_constrained:
     - conda-verify  >=3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 19a5568e09ee476c7e9e68e00583f8ff1e4ca16b709e5078552156194ecd14ee
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
@@ -24,7 +24,8 @@ build:
 
 requirements:
   build:
-    - m2-patch           # [win]
+    - patch    >=2.6     # [not win]
+    - m2-patch >=2.6     # [win]
     - python                               # [build_platform != target_platform]
     - cross-python_{{ target_platform }}   # [build_platform != target_platform]
   host:
@@ -51,7 +52,8 @@ requirements:
     - conda-package-handling >=1.3
     - python-libarchive-c
     - requests
-    - m2-patch           # [win]
+    - patch    >=2.6     # [not win]
+    - m2-patch >=2.6     # [win]
 
   run_constrained:
     - conda-verify  >=3.1.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Xref: conda/conda-build#4495

<!--
Please add any other relevant info below:
-->

In addressing the flakiness of conda-build's patch tests we found that the default `patch` shipped on MacOS (2.5.8) is insufficient (need >=2.6).