### PR TITLE
Set upper bound on setuptools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f535f70cbe6a02fb41ced284df97e0d9b9e779131d9ef550644bd5f05ef48f30
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
@@ -44,7 +44,10 @@ requirements:
     - py-lief
     - pyyaml
     - ripgrep
-    - setuptools
+    # setuptools 66 broke conda-build
+    # unpin when the issue below is resolved
+    # https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973
+    - setuptools <66.0.0a0
     - six
     - glob2 >=0.6
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: f535f70cbe6a02fb41ced284df97e0d9b9e779131d9ef550644bd5f05ef48f30
+  sha256: 53e9824850822c6a2b44a6b493c8d24161cedec3d74d7dc488278e2bc6ac8ab1
 
 build:
   number: 1


### PR DESCRIPTION
Typically we "fix" the feedstock so as to avoid accidentally creating a new release.

Just wanted to make sure this got in
xref:
* https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/387
* https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
