### PR TITLE
restrict py-lief to <0.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a4fab906e6cbe3dc1a540012dc81500bbb99fe79be6454021042aa9a1d7f66ef
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - conda-build = conda_build.cli.main_build:execute
@@ -50,7 +50,7 @@ requirements:
     - pkginfo
     - psutil
     # https://github.com/conda/conda-build/issues/5594
-    - py-lief <0.16
+    - py-lief <0.15
     - python
     - python-libarchive-c
     - pytz


### PR DESCRIPTION
take #239 a step further (matches latest repodata patch https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/947)

conda-build 25.1.1 is not yet compatible with lief 0.15, at least on mac https://github.com/conda/conda-build/issues/5594
