### PR TITLE
Remove pytz dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "26.3.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: conda-build
@@ -60,7 +60,6 @@ requirements:
     - python >={{ python_min }}
 {% endif %}
     - python-libarchive-c
-    - pytz
     - pyyaml
     - rattler-build
     - requests


### PR DESCRIPTION
Dropped from upstream conda-build dependencies in 26.3

Actually unused since conda-build 24.3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
